### PR TITLE
fix npm script names

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "1.26.4",
   "license": "Apache 2.0",
   "scripts": {
-    "dev": "gatsby develop -H 0.0.0.0",
-    "dev:clean": "yarn clean && yarn develop",
+    "develop": "gatsby develop -H 0.0.0.0",
+    "develop:clean": "yarn clean && yarn develop",
     "build": "gatsby build",
     "build:clean": "yarn clean && gatsby build",
     "serve": "gatsby serve",


### PR DESCRIPTION
matches npm script names to the guide and aligns with `gatsby develop`

Fixes #9 